### PR TITLE
Use buffered channels for Timers to avoid a hang on mock.Add.

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -175,7 +175,7 @@ func (m *Mock) Tick(d time.Duration) <-chan time.Time {
 func (m *Mock) Ticker(d time.Duration) *Ticker {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ch := make(chan time.Time)
+	ch := make(chan time.Time, 1)
 	t := &Ticker{
 		C:    ch,
 		c:    ch,
@@ -191,7 +191,7 @@ func (m *Mock) Ticker(d time.Duration) *Ticker {
 func (m *Mock) Timer(d time.Duration) *Timer {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ch := make(chan time.Time)
+	ch := make(chan time.Time, 1)
 	t := &Timer{
 		C:    ch,
 		c:    ch,
@@ -287,7 +287,7 @@ func (t *internalTicker) Next() time.Time { return t.next }
 func (t *internalTicker) Tick(now time.Time) {
 	select {
 	case t.c <- now:
-	case <-time.After(1 * time.Millisecond):
+	default:
 	}
 	t.next = now.Add(t.d)
 	gosched()


### PR DESCRIPTION
With unbuffered channels, `mock.Add` will hang when doing things like:

```go
select {
	case <-myChannel:
		doSomething()

	case <-clock.After(100 * time.Millisecond):
}
```

Then, in a test:

```go
somethingThatWritesMyChannel()

mock.Add(200 * time.Millisecond)
```

Under the hood, `Add` will write to the channel returned by `clock.After()`. If the channel is unbuffered, it hangs, since the goroutine isn't reading from the channel.

For reference, the standard library uses a buffered channel for its timers: https://github.com/golang/go/blob/master/src/time/sleep.go#L67