### PR TITLE
Fix unit test failures when running on multiple cpus

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,7 +1,6 @@
 package clock
 
 import (
-	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -294,4 +293,4 @@ func (t *internalTicker) Tick(now time.Time) {
 }
 
 // Sleep momentarily so that other goroutines can process.
-func gosched() { runtime.Gosched() }
+func gosched() { time.Sleep(1 * time.Millisecond) }


### PR DESCRIPTION
As reported in #4, unit tests fail when running with multiple CPUs.

The code was relying on `runtime.Gosched()` to pause the current goroutine and run some other one for long enough to get its timer, sleep, or whatever into the `clock` data structures.  This was never really reliable, and when the two goroutines are running on different CPUs `runtime.Gosched()` is likely to do nothing at all.

These changes remove all use of `runtime.Gosched()`, either by introducing a `ready` channel which synchronises the two sides, or by going back to your earlier approach of sleeping for a short time.  Sleeping is not 100% reliable either, but far more likely to achieve the desired effect.