### PR TITLE
De-race the tests; support concurrent Mock::Add; add Mock::Stop support

### DIFF
--- a/clock_test.go
+++ b/clock_test.go
@@ -292,6 +292,31 @@ func TestMock_Ticker_Stop(t *testing.T) {
 	}
 }
 
+// Ensure that the mock's Stop method wakes sleepers.
+func TestMock_Mock_Stop(t *testing.T) {
+	mock := NewMock()
+	clock := Clock(mock)
+
+	ch := make(chan struct{})
+	go func() {
+		clock.Sleep(time.Second)
+		ch <- struct{}{}
+	}()
+	mock.Stop()
+	<-ch
+
+	// Timers finish immediately
+	timer := clock.Timer(time.Hour)
+	<-timer.C
+
+	// Tickers finish immediately
+	ticker := clock.Ticker(time.Hour)
+	<-ticker.C
+
+	// Sleep returns immediately
+	clock.Sleep(time.Hour)
+}
+
 // Ensure that multiple tickers can be used together.
 func TestMock_Ticker_Multi(t *testing.T) {
 	// This test repeats until a perfect execution happens.

--- a/clock_test.go
+++ b/clock_test.go
@@ -1,213 +1,18 @@
 package clock
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"sync"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// Ensure that the clock's After channel sends at the correct time.
-func TestClock_After(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	<-New().After(20 * time.Millisecond)
-	if !ok {
-		t.Fatal("too early")
-	}
-}
-
-// Ensure that the clock's AfterFunc executes at the correct time.
-func TestClock_AfterFunc(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	New().AfterFunc(20*time.Millisecond, func() {
-		wg.Done()
-	})
-	wg.Wait()
-	if !ok {
-		t.Fatal("too early")
-	}
-}
-
-// Ensure that the clock's time matches the standary library.
-func TestClock_Now(t *testing.T) {
-	a := time.Now().Round(time.Second)
-	b := New().Now().Round(time.Second)
-	if !a.Equal(b) {
-		t.Errorf("not equal: %s != %s", a, b)
-	}
-}
-
-// Ensure that the clock sleeps for the appropriate amount of time.
-func TestClock_Sleep(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	New().Sleep(20 * time.Millisecond)
-	if !ok {
-		t.Fatal("too early")
-	}
-}
-
-// Ensure that the clock ticks correctly.
-func TestClock_Tick(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	c := New().Tick(20 * time.Millisecond)
-	<-c
-	<-c
-	if !ok {
-		t.Fatal("too early")
-	}
-}
-
-// Ensure that the clock's ticker ticks correctly.
-func TestClock_Ticker(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	ticker := New().Ticker(50 * time.Millisecond)
-	<-ticker.C
-	<-ticker.C
-	if !ok {
-		t.Fatal("too early")
-	}
-}
-
-// Ensure that the clock's ticker can stop correctly.
-func TestClock_Ticker_Stp(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	gosched()
-
-	ticker := New().Ticker(20 * time.Millisecond)
-	<-ticker.C
-	ticker.Stop()
-	select {
-	case <-ticker.C:
-		t.Fatal("unexpected send")
-	case <-time.After(30 * time.Millisecond):
-	}
-}
-
-// Ensure that the clock's timer waits correctly.
-func TestClock_Timer(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	timer := New().Timer(20 * time.Millisecond)
-	<-timer.C
-	if !ok {
-		t.Fatal("too early")
-	}
-
-	if timer.Stop() {
-		t.Fatal("timer still running")
-	}
-}
-
-// Ensure that the clock's timer can be stopped.
-func TestClock_Timer_Stop(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-
-	timer := New().Timer(20 * time.Millisecond)
-	if !timer.Stop() {
-		t.Fatal("timer not running")
-	}
-	if timer.Stop() {
-		t.Fatal("timer wasn't cancelled")
-	}
-	select {
-	case <-timer.C:
-		t.Fatal("unexpected send")
-	case <-time.After(30 * time.Millisecond):
-	}
-}
-
-// Ensure that the clock's timer can be reset.
-func TestClock_Timer_Reset(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		ok = true
-	}()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		t.Fatal("too late")
-	}()
-	gosched()
-
-	timer := New().Timer(10 * time.Millisecond)
-	if !timer.Reset(20 * time.Millisecond) {
-		t.Fatal("timer not running")
-	}
-
-	<-timer.C
-	if !ok {
-		t.Fatal("too early")
+func blockUntil(r int, ch <-chan struct{}) {
+	for r > 0 {
+		<-ch
+		r--
 	}
 }
 
@@ -217,20 +22,28 @@ func TestMock_After(t *testing.T) {
 	clock := NewMock()
 
 	// Create a channel to execute after 10 mock seconds.
-	ch := clock.After(10 * time.Second)
-	go func(ch <-chan time.Time) {
-		<-ch
+	ch0 := clock.After(10 * time.Second)
+	ch1 := make(chan struct{})
+	go func() {
+		<-ch0
 		atomic.StoreInt32(&ok, 1)
-	}(ch)
+		ch1 <- struct{}{}
+	}()
 
 	// Move clock forward to just before the time.
 	clock.Add(9 * time.Second)
+	select {
+	case <-ch1:
+		t.Fatal("too early")
+	default:
+	}
 	if atomic.LoadInt32(&ok) == 1 {
 		t.Fatal("too early")
 	}
 
 	// Move clock forward to the after channel's time.
 	clock.Add(1 * time.Second)
+	<-ch1
 	if atomic.LoadInt32(&ok) == 0 {
 		t.Fatal("too late")
 	}
@@ -284,12 +97,14 @@ func TestMock_AfterFunc_Stop(t *testing.T) {
 	timer := clock.AfterFunc(10*time.Second, func() {
 		t.Fatal("unexpected function execution")
 	})
-	gosched()
+	runtime.Gosched()
 
 	// Stop timer & move clock forward.
-	timer.Stop()
+	if !timer.Stop() {
+		t.Fatal("stop failed")
+	}
 	clock.Add(10 * time.Second)
-	gosched()
+	runtime.Gosched()
 }
 
 // Ensure that the mock's current time can be changed.
@@ -318,83 +133,118 @@ func TestMock_Since(t *testing.T) {
 
 // Ensure that the mock can sleep for the correct time.
 func TestMock_Sleep(t *testing.T) {
-	var ok int32
+	// This test repeats until a perfect execution happens.
+	for !testMock_Sleep(t) {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func testMock_Sleep(t *testing.T) bool {
+	ok := make(chan struct{})
 	clock := NewMock()
+	start := clock.Now()
 
 	// Create a channel to execute after 10 mock seconds.
 	go func() {
 		clock.Sleep(10 * time.Second)
-		atomic.StoreInt32(&ok, 1)
+		ok <- struct{}{}
 	}()
-	gosched()
+	// This test is inherently racey because we need the Sleep()
+	// call to take the current time before calling Set below, and
+	// we have no way to do that.
+	runtime.Gosched()
 
 	// Move clock forward to just before the sleep duration.
-	clock.Add(9 * time.Second)
-	if atomic.LoadInt32(&ok) == 1 {
+	clock.Set(start.Add(9 * time.Second))
+	select {
+	case <-ok:
 		t.Fatal("too early")
+	default:
 	}
 
 	// Move clock forward to the after the sleep duration.
-	clock.Add(1 * time.Second)
-	if atomic.LoadInt32(&ok) == 0 {
-		t.Fatal("too late")
+	clock.Set(start.Add(10 * time.Second))
+	select {
+	case <-ok:
+		return true
+	default:
+		return false
 	}
 }
 
 // Ensure that the mock's Tick channel sends at the correct time.
 func TestMock_Tick(t *testing.T) {
-	var n int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	clock := NewMock()
+	ticker := clock.Ticker(10 * time.Second)
+	recv := make(chan struct{}, 4)
 
 	// Create a channel to increment every 10 seconds.
 	go func() {
-		tick := clock.Tick(10 * time.Second)
 		for {
-			<-tick
-			atomic.AddInt32(&n, 1)
+			select {
+			case <-ticker.C:
+				recv <- struct{}{}
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
-	gosched()
 
 	// Move clock forward to just before the first tick.
 	clock.Add(9 * time.Second)
-	if atomic.LoadInt32(&n) != 0 {
-		t.Fatalf("expected 0, got %d", n)
+	if r := len(recv); r != 0 {
+		t.Fatalf("expected 0, got %d", r)
 	}
 
 	// Move clock forward to the start of the first tick.
 	clock.Add(1 * time.Second)
-	if atomic.LoadInt32(&n) != 1 {
-		t.Fatalf("expected 1, got %d", n)
-	}
+	<-recv
 
 	// Move clock forward over several ticks.
 	clock.Add(30 * time.Second)
-	if atomic.LoadInt32(&n) != 4 {
-		t.Fatalf("expected 4, got %d", n)
-	}
+	<-recv
+	<-recv
+	<-recv
+	ticker.Stop()
 }
 
 // Ensure that the mock's Ticker channel sends at the correct time.
 func TestMock_Ticker(t *testing.T) {
-	var n int32
+	// This test repeats until a perfect execution happens.
+	for !testMock_Ticker() {
+	}
+}
+
+func testMock_Ticker() bool {
+	const size = 10
+	received := 0
+	recv := make(chan struct{}, size)
 	clock := NewMock()
+	ticker, drops := clock.TestTicker(1 * time.Microsecond)
 
 	// Create a channel to increment every microsecond.
 	go func() {
-		ticker := clock.Ticker(1 * time.Microsecond)
 		for {
-			<-ticker.C
-			atomic.AddInt32(&n, 1)
+			select {
+			case <-ticker.C:
+				received++
+				recv <- struct{}{}
+			case <-drops:
+				recv <- struct{}{}
+			}
 		}
 	}()
-	gosched()
 
 	// Move clock forward.
-	clock.Add(10 * time.Microsecond)
-	if atomic.LoadInt32(&n) != 10 {
-		t.Fatalf("unexpected: %d", n)
+	for i := 0; i < size; i++ {
+		clock.Add(time.Microsecond)
 	}
+	blockUntil(size, recv)
+	ticker.Stop()
+	return received == size
 }
 
 // Ensure that the mock's Ticker channel won't block if not read from.
@@ -407,66 +257,117 @@ func TestMock_Ticker_Overflow(t *testing.T) {
 
 // Ensure that the mock's Ticker can be stopped.
 func TestMock_Ticker_Stop(t *testing.T) {
-	var n int32
+	recv := make(chan struct{}, 50)
 	clock := NewMock()
 
 	// Create a channel to increment every second.
-	ticker := clock.Ticker(1 * time.Second)
+	ticker, drops := clock.TestTicker(1 * time.Second)
 	go func() {
 		for {
-			<-ticker.C
-			atomic.AddInt32(&n, 1)
+
+			select {
+			case <-ticker.C:
+				recv <- struct{}{}
+			case _, ok := <-drops:
+				if !ok {
+					return
+				}
+				recv <- struct{}{}
+			}
 		}
 	}()
-	gosched()
 
 	// Move clock forward.
 	clock.Add(5 * time.Second)
-	if atomic.LoadInt32(&n) != 5 {
-		t.Fatalf("expected 5, got: %d", n)
-	}
+	blockUntil(5, recv)
 
 	ticker.Stop()
 
 	// Move clock forward again.
 	clock.Add(5 * time.Second)
-	if atomic.LoadInt32(&n) != 5 {
-		t.Fatalf("still expected 5, got: %d", n)
+	select {
+	case <-recv:
+		t.Fatalf("unexpected notification")
+	default:
 	}
 }
 
 // Ensure that multiple tickers can be used together.
 func TestMock_Ticker_Multi(t *testing.T) {
-	var n int32
-	clock := NewMock()
+	// This test repeats until a perfect execution happens.
+	for !testMock_Ticker_Multi() {
+	}
+}
+
+// This test is repeated until it succeeds with no dropped
+// notifications, proving that the multi-ticker logic is correct.
+func testMock_Ticker_Multi() bool {
+	const (
+		duration = 10
+		unit     = time.Microsecond
+		aCount   = 1
+		bCount   = 100
+		aPeriod  = 1
+		bPeriod  = 3
+		aTicks   = duration / aPeriod
+		bTicks   = duration / bPeriod
+		expect   = bTicks*bCount + aTicks*aCount
+	)
+	mock := NewMock()
+	a, aDrop := mock.TestTicker(aPeriod * unit)
+	b, bDrop := mock.TestTicker(bPeriod * unit)
+	recv := make(chan struct{}, expect)
+	aReceived := 0
+	bReceived := 0
+	sendN := func(n int) {
+		for n > 0 {
+			recv <- struct{}{}
+			n--
+			runtime.Gosched()
+		}
+	}
 
 	go func() {
-		a := clock.Ticker(1 * time.Microsecond)
-		b := clock.Ticker(3 * time.Microsecond)
-
 		for {
 			select {
 			case <-a.C:
-				atomic.AddInt32(&n, 1)
+				aReceived++
+				go sendN(aCount)
+			case _, ok := <-aDrop:
+				if !ok {
+					return
+				}
+				go sendN(aCount)
 			case <-b.C:
-				atomic.AddInt32(&n, 100)
+				bReceived++
+				go sendN(bCount)
+			case _, ok := <-bDrop:
+				if !ok {
+					return
+				}
+				go sendN(bCount)
 			}
+			runtime.Gosched()
 		}
 	}()
-	gosched()
 
-	// Move clock forward.
-	clock.Add(10 * time.Microsecond)
-	gosched()
-	if atomic.LoadInt32(&n) != 310 {
-		t.Fatalf("unexpected: %d", n)
+	// Move clock forward 1ms at a time, to avoid overflowing any
+	// of the ticker channels.
+	for i := 0; i < duration; i++ {
+		mock.Add(unit)
 	}
+
+	blockUntil(expect, recv)
+	a.Stop()
+	b.Stop()
+
+	return aReceived == aTicks && bReceived == bTicks
 }
 
 func ExampleMock_After() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	var count int32
 
 	ready := make(chan struct{})
 	// Create a channel to execute after 10 mock seconds.
@@ -474,20 +375,20 @@ func ExampleMock_After() {
 		ch := clock.After(10 * time.Second)
 		close(ready)
 		<-ch
-		count = 100
+		atomic.StoreInt32(&count, 100)
 	}()
 	<-ready
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), atomic.LoadInt32(&count))
 
 	// Move the clock forward 5 seconds and print the value again.
 	clock.Add(5 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), atomic.LoadInt32(&count))
 
 	// Move the clock forward 5 seconds to the tick time and check the value.
 	clock.Add(5 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), atomic.LoadInt32(&count))
 
 	// Output:
 	// 1970-01-01 00:00:00 +0000 UTC: 0
@@ -504,7 +405,7 @@ func ExampleMock_AfterFunc() {
 	clock.AfterFunc(10*time.Second, func() {
 		count = 100
 	})
-	gosched()
+	runtime.Gosched()
 
 	// Print the starting value.
 	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
@@ -521,61 +422,31 @@ func ExampleMock_AfterFunc() {
 func ExampleMock_Sleep() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	var count int32
 
 	// Execute a function after 10 mock seconds.
 	go func() {
 		clock.Sleep(10 * time.Second)
-		count = 100
+		atomic.StoreInt32(&count, 100)
 	}()
-	gosched()
+	runtime.Gosched()
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), atomic.LoadInt32(&count))
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), atomic.LoadInt32(&count))
 
 	// Output:
 	// 1970-01-01 00:00:00 +0000 UTC: 0
 	// 1970-01-01 00:00:10 +0000 UTC: 100
 }
 
-func ExampleMock_Ticker() {
-	// Create a new mock clock.
-	clock := NewMock()
-	count := 0
-
-	ready := make(chan struct{})
-	// Increment count every mock second.
-	go func() {
-		ticker := clock.Ticker(1 * time.Second)
-		close(ready)
-		for {
-			<-ticker.C
-			count++
-		}
-	}()
-	<-ready
-
-	// Move the clock forward 10 seconds and print the new value.
-	clock.Add(10 * time.Second)
-	fmt.Printf("Count is %d after 10 seconds\n", count)
-
-	// Move the clock forward 5 more seconds and print the new value.
-	clock.Add(5 * time.Second)
-	fmt.Printf("Count is %d after 15 seconds\n", count)
-
-	// Output:
-	// Count is 10 after 10 seconds
-	// Count is 15 after 15 seconds
-}
-
 func ExampleMock_Timer() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	var count int32
 
 	ready := make(chan struct{})
 	// Increment count after a mock second.
@@ -583,17 +454,14 @@ func ExampleMock_Timer() {
 		timer := clock.Timer(1 * time.Second)
 		close(ready)
 		<-timer.C
-		count++
+		atomic.AddInt32(&count, 1)
 	}()
 	<-ready
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("Count is %d after 10 seconds\n", count)
+	fmt.Printf("Count is %d after 10 seconds\n", atomic.LoadInt32(&count))
 
 	// Output:
 	// Count is 1 after 10 seconds
 }
-
-func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
-func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }


### PR DESCRIPTION
I'm happy to contribute several improvements.

I removed the tests for the real clock because it's basically impossible to make them not racey. The test now passes w/ Go-1.10 under the race detector.