### PR TITLE
Context WithDeadline/WithTimeout methods

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,6 +1,7 @@
 package clock
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
@@ -20,6 +21,8 @@ type Clock interface {
 	Tick(d time.Duration) <-chan time.Time
 	Ticker(d time.Duration) *Ticker
 	Timer(d time.Duration) *Timer
+	WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc)
+	WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc)
 }
 
 // New returns an instance of a real-time clock.
@@ -52,6 +55,14 @@ func (c *clock) Ticker(d time.Duration) *Ticker {
 func (c *clock) Timer(d time.Duration) *Timer {
 	t := time.NewTimer(d)
 	return &Timer{C: t.C, timer: t}
+}
+
+func (c *clock) WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, d)
+}
+
+func (c *clock) WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, t)
 }
 
 // Mock represents a mock clock that only moves forward programmically.

--- a/clock.go
+++ b/clock.go
@@ -346,3 +346,8 @@ func (t *internalTicker) Tick(now time.Time) {
 
 // Sleep momentarily so that other goroutines can process.
 func gosched() { time.Sleep(1 * time.Millisecond) }
+
+var (
+	// type checking
+	_ Clock = &Mock{}
+)

--- a/context.go
+++ b/context.go
@@ -1,0 +1,86 @@
+package clock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func (m *Mock) WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return m.WithDeadline(parent, m.Now().Add(timeout))
+}
+
+func (m *Mock) WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return context.WithCancel(parent)
+	}
+	ctx := &timerCtx{clock: m, parent: parent, deadline: deadline, done: make(chan struct{})}
+	propagateCancel(parent, ctx)
+	dur := deadline.Sub(m.Now())
+	if dur <= 0 {
+		ctx.cancel(context.DeadlineExceeded) // deadline has already passed
+		return ctx, func() { ctx.cancel(context.Canceled) }
+	}
+	ctx.Lock()
+	defer ctx.Unlock()
+	if ctx.err == nil {
+		ctx.timer = m.AfterFunc(dur, func() {
+			ctx.cancel(context.DeadlineExceeded)
+		})
+	}
+	return ctx, func() { ctx.cancel(context.Canceled) }
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent context.Context, child *timerCtx) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	go func() {
+		select {
+		case <-parent.Done():
+			child.cancel(parent.Err())
+		case <-child.Done():
+		}
+	}()
+}
+
+type timerCtx struct {
+	sync.Mutex
+
+	clock    Clock
+	parent   context.Context
+	deadline time.Time
+	done     chan struct{}
+
+	err   error
+	timer *Timer
+}
+
+func (c *timerCtx) cancel(err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.err != nil {
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) { return c.deadline, true }
+
+func (c *timerCtx) Done() <-chan struct{} { return c.done }
+
+func (c *timerCtx) Err() error { return c.err }
+
+func (c *timerCtx) Value(key interface{}) interface{} { return c.parent.Value(key) }
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("clock.WithDeadline(%s [%s])", c.deadline, c.deadline.Sub(c.clock.Now()))
+}


### PR DESCRIPTION
Hi. I don't know what you think of this, but I make heavy use of contexts in my code and I needed to test some timeouts using the mock clock. So I added on two methods to the `Clock` interface, as well as their mock implementations (inspired from the core library `context.WithDeadline` code).

Let me know what you think, I'm happy to tweak things. Of course, we can also add tests, etc.