### PR TITLE
Fix data race between timer Reset and Add; unlock before gosched

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -296,9 +296,8 @@ func (t *internalTimer) Tick(now time.Time) {
 	}
 	t.mock.removeClockTimer((*internalTimer)(t))
 	t.mock.mu.Lock()
-	defer t.mock.mu.Unlock()
-
 	t.stopped = true
+	t.mock.mu.Unlock()
 	gosched()
 }
 

--- a/clock.go
+++ b/clock.go
@@ -272,8 +272,8 @@ func (t *Timer) Reset(d time.Duration) bool {
 		return t.timer.Reset(d)
 	}
 
-	t.next = t.mock.now.Add(d)
 	t.mock.mu.Lock()
+	t.next = t.mock.now.Add(d)
 	defer t.mock.mu.Unlock()
 
 	registered := !t.stopped

--- a/clock_test.go
+++ b/clock_test.go
@@ -211,6 +211,30 @@ func TestClock_Timer_Reset(t *testing.T) {
 	}
 }
 
+// Ensure reset can be called immediately after reading channel
+func TestClock_Timer_Reset_Unlock(t *testing.T) {
+	clock := NewMock()
+	timer := clock.Timer(1 * time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		select {
+		case <-timer.C:
+			timer.Reset(1 * time.Second)
+		}
+
+		select {
+		case <-timer.C:
+		}
+	}()
+
+	clock.Add(2 * time.Second)
+	wg.Wait()
+}
+
 // Ensure that the mock's After channel sends at the correct time.
 func TestMock_After(t *testing.T) {
 	var ok int32


### PR DESCRIPTION
Fix data race below when advancing the clock.


Also unlock the mutex in Tick before calling gosched(), without this change the included test case hangs.


```
WARNING: DATA RACE
Write at 0x00c000161248 by goroutine 41:
  github.com/benbjohnson/clock.(*Mock).Add()
      /home/dbn/src/influx/src/github.com/influxdata/telegraf/vendor/github.com/benbjohnson/clock/clock.go:86 +0xf6
  github.com/influxdata/telegraf/agent.TestAlignedTickerMissedTick()
      /home/dbn/src/influx/src/github.com/influxdata/telegraf/agent/tick_test.go:79 +0x1ab
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:991 +0x1eb

Previous read at 0x00c000161248 by goroutine 42:
  github.com/benbjohnson/clock.(*Timer).Reset()
      /home/dbn/src/influx/src/github.com/influxdata/telegraf/vendor/github.com/benbjohnson/clock/clock.go:275 +0xba
  github.com/influxdata/telegraf/agent.(*AlignedTicker).run()
      /home/dbn/src/influx/src/github.com/influxdata/telegraf/agent/tick.go:89 +0x8b
  github.com/influxdata/telegraf/agent.newAlignedTicker.func1()
      /home/dbn/src/influx/src/github.com/influxdata/telegraf/agent/tick.go:60 +0x9f
```