### PR TITLE
Introduce ticker Reset

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -317,6 +317,13 @@ func (t *Ticker) Stop() {
 	}
 }
 
+// Reset resets the ticker to a new duration.
+func (t *Ticker) Reset(dur time.Duration) {
+	if t.ticker != nil {
+		t.ticker.Reset(dur)
+	}
+}
+
 type internalTicker Ticker
 
 func (t *internalTicker) Next() time.Time { return t.next }

--- a/clock_test.go
+++ b/clock_test.go
@@ -124,13 +124,6 @@ func TestClock_Ticker(t *testing.T) {
 
 // Ensure that the clock's ticker can stop correctly.
 func TestClock_Ticker_Stp(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-	gosched()
-
 	ticker := New().Ticker(20 * time.Millisecond)
 	<-ticker.C
 	ticker.Stop()
@@ -139,6 +132,25 @@ func TestClock_Ticker_Stp(t *testing.T) {
 		t.Fatal("unexpected send")
 	case <-time.After(30 * time.Millisecond):
 	}
+}
+
+// Ensure that the clock's ticker can reset correctly.
+func TestClock_Ticker_Rst(t *testing.T) {
+	var ok bool
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		ok = true
+	}()
+	gosched()
+
+	ticker := New().Ticker(20 * time.Millisecond)
+	<-ticker.C
+	ticker.Reset(5 * time.Millisecond)
+	<-ticker.C
+	if ok {
+		t.Fatal("too late")
+	}
+	ticker.Stop()
 }
 
 // Ensure that the clock's timer waits correctly.
@@ -167,12 +179,6 @@ func TestClock_Timer(t *testing.T) {
 
 // Ensure that the clock's timer can be stopped.
 func TestClock_Timer_Stop(t *testing.T) {
-	var ok bool
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		ok = true
-	}()
-
 	timer := New().Timer(20 * time.Millisecond)
 	if !timer.Stop() {
 		t.Fatal("timer not running")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/benbjohnson/clock
 
-go 1.13
+go 1.15


### PR DESCRIPTION
Go 1.15 [introduces the `Reset` method on the `time.Ticker` object](https://golang.org/doc/go1.15#time). I had a need for this, so I thought I'd share my branch.

It is a very simple take which makes no attempt at mocking the method, instead ignoring it in the mock implementation. I can of course make changes for `Reset` to be mocked as well, although I am curious what that would look like in terms of behavior.