### PR TITLE
unlock context during fn call

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -286,7 +286,9 @@ func (t *internalTimer) Next() time.Time { return t.next }
 func (t *internalTimer) Tick(now time.Time) {
 	t.mock.mu.Lock()
 	if t.fn != nil {
+		t.mock.mu.Unlock()
 		t.fn()
+		t.mock.mu.Lock()
 	} else {
 		t.c <- now
 	}


### PR DESCRIPTION
Hi!

There is a dead lock if you create a AfterFunc callback with a call to Now(). This request basically unlocks the context before calling fn so you can trigger other operations.