### PR TITLE
Mock: Fix AfterFunc data race

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -167,7 +167,9 @@ func (m *Mock) After(d time.Duration) <-chan time.Time {
 func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
 	t := m.Timer(d)
 	t.C = nil
+	m.mu.Lock()
 	t.fn = f
+	m.mu.Unlock()
 	return t
 }
 


### PR DESCRIPTION
There's a data race if we call Mock.AfterFunc and Mock.Add
concurrently.

The included test demonstrates this with `go test -race`.

```
$ go test -race
==================
WARNING: DATA RACE
Read at 0x00c0000a64e8 by goroutine 50:
  github.com/benbjohnson/clock.(*internalTimer).Tick()
      [...]/clock/clock.go:314 +0xc4
  github.com/benbjohnson/clock.(*Mock).runNextTimer()
      [...]/clock/clock.go:156 +0x1ce
  github.com/benbjohnson/clock.(*Mock).Add()
      [...]/clock/clock.go:96 +0x97
  github.com/benbjohnson/clock.TestMock_AddAfterFuncRace.func3()
      [...]/clock/clock_test.go:687 +0xa7

Previous write at 0x00c0000a64e8 by goroutine 49:
  github.com/benbjohnson/clock.(*Mock).AfterFunc()
      [...]/clock/clock.go:170 +0x178
  github.com/benbjohnson/clock.TestMock_AddAfterFuncRace.func2()
      [...]/clock/clock_test.go:677 +0xb9

Goroutine 50 (running) created at:
  github.com/benbjohnson/clock.TestMock_AddAfterFuncRace()
      [...]/clock/clock_test.go:683 +0x464
  testing.tRunner()
      [...]/go/1.17.2/libexec/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      [...]/go/1.17.2/libexec/src/testing/testing.go:1306 +0x47

Goroutine 49 (finished) created at:
  github.com/benbjohnson/clock.TestMock_AddAfterFuncRace()
      [...]/clock/clock_test.go:673 +0x347
  testing.tRunner()
      [...]/go/1.17.2/libexec/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      [...]/go/1.17.2/libexec/src/testing/testing.go:1306 +0x47
==================
--- FAIL: TestMock_AddAfterFuncRace (0.01s)
    testing.go:1152: race detected during execution of test
FAIL
exit status 1
```

Fix the race by applying the same mutex used while reading `t.fn`
in `internalTimer.Tick`.
