### PR TITLE
Minimal GitHub Workflow for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Go
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go: ["1.16.x", "1.17.x"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Load cached dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+    - name: Test
+      run: go test -v -race ./...


### PR DESCRIPTION
Add a minimal GitHub Workflow configuration for CI on the project.
This will test against both currently supported versions of Go per
the [Go Compatibility Guarantee](https://golang.org/doc/go1compat).
