### PR TITLE
AfterFunc underlying function is executed in its own goroutine

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -162,7 +162,7 @@ func (m *Mock) After(d time.Duration) <-chan time.Time {
 	return m.Timer(d).C
 }
 
-// AfterFunc waits for the duration to elapse and then executes a function.
+// AfterFunc waits for the duration to elapse and then executes a function in its own goroutine.
 // A Timer is returned that can be stopped.
 func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
 	t := m.Timer(d)
@@ -313,7 +313,7 @@ func (t *internalTimer) Tick(now time.Time) {
 	t.mock.mu.Lock()
 	if t.fn != nil {
 		// defer function execution until the lock is released, and
-		defer t.fn()
+		defer func() { go t.fn() }()
 	} else {
 		t.c <- now
 	}

--- a/clock_test.go
+++ b/clock_test.go
@@ -538,24 +538,25 @@ func ExampleMock_After() {
 func ExampleMock_AfterFunc() {
 	// Create a new mock clock.
 	clock := NewMock()
-	count := 0
+	var count counter
+	count.incr()
 
 	// Execute a function after 10 mock seconds.
 	clock.AfterFunc(10*time.Second, func() {
-		count = 100
+		count.incr()
 	})
 	gosched()
 
 	// Print the starting value.
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.get())
 
 	// Move the clock forward 10 seconds and print the new value.
 	clock.Add(10 * time.Second)
-	fmt.Printf("%s: %d\n", clock.Now().UTC(), count)
+	fmt.Printf("%s: %d\n", clock.Now().UTC(), count.get())
 
 	// Output:
-	// 1970-01-01 00:00:00 +0000 UTC: 0
-	// 1970-01-01 00:00:10 +0000 UTC: 100
+	// 1970-01-01 00:00:00 +0000 UTC: 1
+	// 1970-01-01 00:00:10 +0000 UTC: 2
 }
 
 func ExampleMock_Sleep() {

--- a/clock_test.go
+++ b/clock_test.go
@@ -726,9 +726,9 @@ func TestMock_AddAfterFuncRace(t *testing.T) {
 
 	mockedClock := NewMock()
 
-	called := false
+	var calls counter
 	defer func() {
-		if !called {
+		if calls.get() == 0 {
 			t.Errorf("AfterFunc did not call the function")
 		}
 	}()
@@ -739,7 +739,7 @@ func TestMock_AddAfterFuncRace(t *testing.T) {
 		<-start
 
 		mockedClock.AfterFunc(time.Millisecond, func() {
-			called = true
+			calls.incr()
 		})
 	}()
 


### PR DESCRIPTION
Original AfterFunc executes function in its own goroutine
Mock should do it in the same way, otherwise tests doesn't cover races with this kind of timer