### PR TITLE
Add method to forward time until all timers are expired

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -126,6 +126,23 @@ func (m *Mock) Set(t time.Time) {
 	gosched()
 }
 
+// WaitForAllTimers sets the clock until all timers are expired
+func (m *Mock) WaitForAllTimers() time.Time {
+	// Continue to execute timers until there are no more
+	for {
+		m.mu.Lock()
+		if len(m.timers) == 0 {
+			m.mu.Unlock()
+			return m.Now()
+		}
+
+		sort.Sort(m.timers)
+		next := m.timers[len(m.timers)-1].Next()
+		m.mu.Unlock()
+		m.Set(next)
+	}
+}
+
 // runNextTimer executes the next timer in chronological order and moves the
 // current time to the timer's next tick time. The next time is not executed if
 // its next time is after the max time. Returns true if a timer was executed.


### PR DESCRIPTION
Hi, thanks for this great library!

This PR introduces a method to automatically forward time until past all timers.

A colleague of mine found this library and I immediately replaced my (bad) custom solution with this package. I have a test case though, where I do not know the length and number of timers that the workers have set internally (multiple workers working the same queue with heuristic back off). At one point in that test case I need to forward time until no timers remain active.

