### PR TITLE
Fix race condition in Mock.AfterFunc()

### DIFF
--- a/clock_test.go
+++ b/clock_test.go
@@ -650,5 +650,44 @@ func TestMock_ReentrantDeadlock(t *testing.T) {
 	mockedClock.Add(15 * time.Second)
 }
 
+func TestMock_AddAfterFuncRace(t *testing.T) {
+	// start blocks the goroutines in this test
+	// until we're ready for them to race.
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	mockedClock := NewMock()
+
+	called := false
+	defer func() {
+		if !called {
+			t.Errorf("AfterFunc did not call the function")
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+
+		mockedClock.AfterFunc(time.Millisecond, func() {
+			called = true
+		})
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+
+		mockedClock.Add(time.Millisecond)
+		mockedClock.Add(time.Millisecond)
+	}()
+
+	close(start) // unblock the goroutines
+	wg.Wait()    // and wait for them
+}
+
 func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
 func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }


### PR DESCRIPTION
Previously, AfterFunc() created a timer using Timer() and then added a
function callback to the timer. This created a data race because the
timer could fire between when it is created by Timer() and when the
function callback is set.

Instead, this change created the Timer{} struct and adds it to the
Mock's list of timers inline. This ensures that the function callback is
set before the Timer is able to fire.

The included test was originally authored by @abhinav