### PR TITLE
immediately fire a timer reset to negative duration

### DIFF
--- a/clock_test.go
+++ b/clock_test.go
@@ -195,13 +195,25 @@ func TestClock_Timer_Reset(t *testing.T) {
 	}
 }
 
-func TestClock_NegativeDuration(t *testing.T) {
+func TestClock_Timer_NegativeDuration(t *testing.T) {
 	clock := NewMock()
+	now := clock.Now()
 	timer := clock.Timer(-time.Second)
 	select {
 	case <-timer.C:
 	default:
 		t.Fatal("timer should have fired immediately")
+	}
+
+	timer.Reset(-time.Second)
+	select {
+	case <-timer.C:
+	default:
+		t.Fatal("timer should have fired immediately")
+	}
+
+	if clock.Now() != now {
+		t.Fatal("current time should not have changed")
 	}
 }
 


### PR DESCRIPTION
follow up to #50 
fixes: #56 

This behaviour is equivalent to stdlib timer. 

I'm also ensuring that time doesn't move backwards on creating and resetting negative timers. 