### PR TITLE
Fix race condition on 'now' when creating a timer

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -172,10 +172,11 @@ func (m *Mock) runNextTimer(max time.Time) bool {
 
 	// Move "now" forward and unlock clock.
 	m.now = t.Next()
+	now := m.now
 	m.mu.Unlock()
 
 	// Execute timer.
-	t.Tick(m.now)
+	t.Tick(now)
 	return true
 }
 
@@ -258,8 +259,9 @@ func (m *Mock) Timer(d time.Duration) *Timer {
 		stopped: false,
 	}
 	m.timers = append(m.timers, (*internalTimer)(t))
+	now := m.now
 	m.mu.Unlock()
-	m.runNextTimer(m.now)
+	m.runNextTimer(now)
 	return t
 }
 

--- a/clock_test.go
+++ b/clock_test.go
@@ -766,5 +766,24 @@ func TestMock_AddAfterFuncRace(t *testing.T) {
 	wg.Wait()    // and wait for them
 }
 
+func TestMock_AfterRace(t *testing.T) {
+	mock := NewMock()
+
+	const num = 10
+	var finished atomic.Int32
+
+	for i := 0; i < num; i++ {
+		go func() {
+			<-mock.After(1 * time.Millisecond)
+			finished.Add(1)
+		}()
+	}
+
+	for finished.Load() < num {
+		mock.Add(time.Second)
+		gosched()
+	}
+}
+
 func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
 func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }


### PR DESCRIPTION
This is a proposed solution to issue #57 

The proposed solution is to capture `m.now` within the lock and use it subsequently after the lock is released. The added test case is somewhat fabricated in order to reproduce the issue initially using `go test ./... -race -count=1`. 